### PR TITLE
Inform user where there are in production script

### DIFF
--- a/scripts/package-commands.sh
+++ b/scripts/package-commands.sh
@@ -5,6 +5,7 @@ if [ "$1" == "build" ]; then
     npm run clean
     npm run iconfont
     mkdir -p ./dist
+    echo "running webpack, this may take some time"
     NODE_ENV='production' webpack
     exit 0
 fi


### PR DESCRIPTION
It's currently confusing when running a command like `yarn run prod` as right before the webpack command (which takes some time) there is the statement `Done!`. To make it less confusing for people perhaps a line could be added to explain what is going on, as webpack doesn't seem to provide any info (or alternatively you could provide more verbose output from webpack).